### PR TITLE
Draft internal API spec

### DIFF
--- a/covid-internal-openapi.json
+++ b/covid-internal-openapi.json
@@ -7,7 +7,7 @@
     },
     "servers": [
         {
-            "url": "internalapi.covidtracking.com/api/v1",
+            "url": "https://internalapi.covidtracking.com/api/v1",
             "description": ""
         }
     ],

--- a/covid-internal-openapi.json
+++ b/covid-internal-openapi.json
@@ -1,395 +1,569 @@
-openapi: 3.0.2
-info:
-    title: COVID Tracking Internal API
-    version: 0.0.1
-    description: COVID Tracking Internal API
-servers:
-    -
-        url: 'https://internalapi.covidtracking.com/api/v1'
-        description: ''
-paths:
-    /public/states/daily:
-        get:
-            tags:
-                - public
-            parameters:
-                -
-                    name: preview
-                    description: |-
-                        If true, returns results using the most recent data in the preview state. 
-                        Otherwise, only published data is returned.
-                    schema:
-                        type: boolean
-                    in: query
-            responses:
-                '200':
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/CoreDataHistoricalState'
-                    description: States daily time series
-            summary: States historical data. Entries saved each day at 4 pm ET.
-    /public/us/daily:
-        get:
-            tags:
-                - public
-            parameters:
-                -
-                    name: preview
-                    description: |-
-                        If true, returns results using the most recent data in the preview state. 
-                        Otherwise, only published data is returned.
-                    schema:
-                        type: boolean
-                    in: query
-            responses:
-                '200':
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/CoreDataHistorical'
-                    description: Daily time series data
-            summary: US historical data. Entries saved each day at 4 pm ET.
-    /batches:
-        get:
-            tags:
-                - batches
-            responses:
-                '200':
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/Batch'
-                    description: Retrieve all known batches
-            summary: Get all known batches
-        post:
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/BatchForPush'
-                required: true
-            tags:
-                - batches
-            responses:
-                '200':
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/BatchPostResult'
-                    description: successful operation
-                '400':
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/IntegrityErrors'
-                    description: Data integrity validation failed
-            summary: Push a new batch of data to the database
-            description: |-
-                The newly added core data will be in the preview state until published. 
-                Updated StateInfo will be immediately edited.
-    '/batches/{batchId}':
-        summary: Retrieve a batch
-        get:
-            tags:
-                - batches
-            responses:
-                '200':
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Batch'
-                    description: Retrieve a batch
-                '404':
-                    description: No such batch ID exists
-            summary: Get a batch
-        delete:
-            responses:
-                '200':
-                    description: Batch removed
-                '404':
-                    description: Batch ID does not exist
-                '405':
-                    description: Batch cannot be deleted because it is in the published state
-            summary: Remove batch
-            description: >-
-                This operation is only applicable to batches in the preview state. Published batches cannot be
-                removed.
-        parameters:
-            -
-                examples:
-                    exampleBatchId:
-                        value: '1234'
-                name: batchId
-                description: The batch ID to manipulate
-                schema:
-                    type: integer
-                in: path
-                required: true
-    '/batches/{batchId}/publish':
-        post:
-            tags:
-                - batches
-            parameters:
-                -
-                    name: batchId
-                    description: 'The batch ID to be published (must be in the preview state). '
-                    schema:
-                        type: integer
-                    in: path
-                    required: true
-            responses:
-                '200':
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/BatchPostResult'
-                    description: Batch has been sucuessfully published
-                '404':
-                    description: No batch ID exists with the specified batchId
-            summary: Publish batch
-            description: Publish a batch currently in the preview state
-        parameters:
-            -
-                name: batchId
-                description: ID of the batch to publish
-                schema:
-                    type: integer
-                in: path
-                required: true
-    /public/states/info:
-        summary: Retrieves the list of states and associated metadata
-        description: The project includes Washington DC and US territories as states
-        get:
-            tags:
-                - public
-            responses:
-                '200':
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/StateInfo'
-                    description: successful operation
-            summary: Retrieve state metadata
-components:
-    schemas:
-        CoreData:
-            $ref: >-
-                https://raw.githubusercontent.com/COVID19Tracking/covid-api-specs/draft-internal-api/covid-shared-datatypes-openapi.json#/components/schemas/CoreData
-        StateInfo:
-            $ref: >-
-                https://raw.githubusercontent.com/COVID19Tracking/covid-api-specs/draft-internal-api/covid-shared-datatypes-openapi.json#/components/schemas/StateInfo
-        BatchForPush:
-            description: A full set of data from the spreadsheet to be sent in a push
-            required:
-                - context
-            type: object
-            properties:
-                context:
-                    $ref: '#/components/schemas/PushContext'
-                    description: ''
-                states:
-                    description: ''
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/StateInfo'
-                coreData:
-                    description: ''
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/CoreDataInternalState'
-        PushContext:
-            description: Metadata about a push
-            required:
-                - dataEntryType
-            type: object
-            properties:
-                shiftLead:
-                    description: An identifier for the shift lead responsible for the batch
-                    type: string
-                batchNote:
-                    description: Additonal notes explaining the batch
-                    type: string
-                dataEntryType:
-                    description: Describes the type of batch. A daily push?
-                    enum:
-                        - daily
-                    type: string
-        BatchPostResult:
-            title: Root Type for BatchPostResult
-            description: Returned by a sucuessful batch operation
-            required:
-                - batchId
-                - isPublished
-            type: object
-            properties:
-                batchId:
-                    format: int32
-                    description: The ID of the batch operation
-                    type: integer
-                isPublished:
-                    description: 'True if the batch is in the published state, false if it is in the preview state'
-                    type: boolean
-            example:
-                batchId: 123
-                isPublished: false
-        CoreDataInternal:
-            description: 'Data fields pushed from the data entry spreadsheet to the database, including all CoreData'
-            type: object
-            allOf:
-                -
-                    type: object
-                    properties:
-                        privateNotes:
-                            description: Private notes from the data entry team
-                            type: string
-                        checker:
-                            description: An identifier (typically initials) for the checker from the Data Entry team
-                            type: string
-                        doubleChecker:
-                            description: >-
-                                An identifier (typically initials) for the double checker from the Data Entry
-                                team
-                            type: string
-                        dataQualityGrade:
-                            description: ''
-                            type: string
-                        lastUpdateIsoUtc:
-                            format: date-time
-                            description: The "as-of" datetime of the data source (not when the data was published)
-                            type: string
-                        dateChecked:
-                            format: date-time
-                            description: The datetime we last visited their website
-                            type: string
-                        publicationDate:
-                            format: date
-                            description: >-
-                                The date that we release the data. When there are historical edits, this value
-                                will be different from the current date.
-                            type: string
-                -
-                    $ref: '#/components/schemas/CoreData'
-        IntegrityErrors:
-            description: 'Data integrity check errors '
-            type: object
-            properties:
-                errors:
-                    type: array
-                    items:
-                        type: string
-            example:
-                errors:
-                    - State 'NY' missing required value 'date'
-        Batch:
-            description: ''
-            required:
-                - batchId
-            type: object
-            properties:
-                batchId:
-                    description: ''
-                    type: integer
-                createdAt:
-                    format: date-time
-                    description: ''
-                    type: string
-                publishedAt:
-                    format: date-time
-                    description: ''
-                    type: string
-                shiftLead:
-                    description: ''
-                    type: string
-                batchNote:
-                    description: ''
-                    type: string
-                dataEntryType:
-                    description: ''
-                    type: string
-                isPublished:
-                    description: ''
-                    type: boolean
-                isRevision:
-                    description: ''
-                    type: boolean
-                coreData:
-                    $ref: '#/components/schemas/CoreDataInternal'
-                    description: ''
-        StateCoreData:
-            description: ''
-            type: object
-            allOf:
-                -
-                    required:
-                        - state
-                    type: object
-                    properties:
-                        state:
-                            description: 'State abbreviation '
-                            type: string
-                -
-                    $ref: '#/components/schemas/CoreData'
-        TimeSeries:
-            description: ''
-            required:
-                - date
-            type: object
-            properties:
-                date:
-                    format: date
-                    description: ''
-                    type: string
-        CoreDataHistorical:
-            description: ''
-            type: object
-            allOf:
-                -
-                    type: object
-                -
-                    $ref: '#/components/schemas/TimeSeries'
-                -
-                    $ref: '#/components/schemas/CoreDataInternal'
-        CoreDataHistoricalState:
-            description: ''
-            required:
-                - state
-            type: object
-            allOf:
-                -
-                    type: object
-                -
-                    $ref: '#/components/schemas/TimeSeries'
-                -
-                    $ref: '#/components/schemas/CoreDataInternalState'
-        CoreDataInternalState:
-            description: ''
-            type: object
-            allOf:
-                -
-                    type: object
-                    properties:
-                        state:
-                            description: ''
-                            type: string
-                -
-                    $ref: '#/components/schemas/CoreDataInternal'
-        CoreDataForPush:
-            description: ''
-            type: object
-            allOf:
-                -
-                    type: object
-                    properties:
-                        date:
-                            format: dataDate
-                            description: ''
-                            type: string
-                -
-                    $ref: '#/components/schemas/CoreDataInternalState'
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "COVID Tracking Internal API",
+        "version": "0.0.1",
+        "description": "COVID Tracking Internal API"
+    },
+    "servers": [
+        {
+            "url": "https://internalapi.covidtracking.com/api/v1",
+            "description": ""
+        }
+    ],
+    "paths": {
+        "/public/states/daily": {
+            "get": {
+                "tags": [
+                    "public"
+                ],
+                "parameters": [
+                    {
+                        "name": "preview",
+                        "description": "If true, returns results using the most recent data in the preview state. \nOtherwise, only published data is returned.",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CoreDataHistoricalState"
+                                }
+                            }
+                        },
+                        "description": "States daily time series"
+                    }
+                },
+                "summary": "States historical data. Entries saved each day at 4 pm ET."
+            }
+        },
+        "/public/us/daily": {
+            "get": {
+                "tags": [
+                    "public"
+                ],
+                "parameters": [
+                    {
+                        "name": "preview",
+                        "description": "If true, returns results using the most recent data in the preview state. \nOtherwise, only published data is returned.",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CoreDataHistorical"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Daily time series data"
+                    }
+                },
+                "summary": "US historical data. Entries saved each day at 4 pm ET."
+            }
+        },
+        "/batches": {
+            "get": {
+                "tags": [
+                    "batches"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Batch"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Retrieve all known batches"
+                    }
+                },
+                "summary": "Get all known batches"
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchForPush"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "tags": [
+                    "batches"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchPostResult"
+                                }
+                            }
+                        },
+                        "description": "successful operation"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/IntegrityErrors"
+                                }
+                            }
+                        },
+                        "description": "Data integrity validation failed"
+                    }
+                },
+                "summary": "Push a new batch of data to the database",
+                "description": "The newly added core data will be in the preview state until published. \nUpdated StateInfo will be immediately edited."
+            }
+        },
+        "/batches/{batchId}": {
+            "summary": "Retrieve a batch",
+            "get": {
+                "tags": [
+                    "batches"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Batch"
+                                }
+                            }
+                        },
+                        "description": "Retrieve a batch"
+                    },
+                    "404": {
+                        "description": "No such batch ID exists"
+                    }
+                },
+                "summary": "Get a batch"
+            },
+            "delete": {
+                "tags": [
+                    "batches"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Batch removed"
+                    },
+                    "404": {
+                        "description": "Batch ID does not exist"
+                    },
+                    "405": {
+                        "description": "Batch cannot be deleted because it is in the published state"
+                    }
+                },
+                "summary": "Remove batch",
+                "description": "This operation is only applicable to batches in the preview state. Published batches cannot be removed."
+            },
+            "parameters": [
+                {
+                    "examples": {
+                        "exampleBatchId": {
+                            "value": "1234"
+                        }
+                    },
+                    "name": "batchId",
+                    "description": "The batch ID to manipulate",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/batches/{batchId}/publish": {
+            "post": {
+                "tags": [
+                    "batches"
+                ],
+                "parameters": [
+                    {
+                        "name": "batchId",
+                        "description": "The batch ID to be published (must be in the preview state). ",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchPostResult"
+                                }
+                            }
+                        },
+                        "description": "Batch has been sucuessfully published"
+                    },
+                    "404": {
+                        "description": "No batch ID exists with the specified batchId"
+                    }
+                },
+                "summary": "Publish batch",
+                "description": "Publish a batch currently in the preview state"
+            },
+            "parameters": [
+                {
+                    "name": "batchId",
+                    "description": "ID of the batch to publish",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/public/states/info": {
+            "summary": "Retrieves the list of states and associated metadata",
+            "description": "The project includes Washington DC and US territories as states",
+            "get": {
+                "tags": [
+                    "public"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/StateInfo"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "successful operation"
+                    }
+                },
+                "summary": "Retrieve state metadata"
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "CoreData": {
+                "$ref": "https://raw.githubusercontent.com/COVID19Tracking/covid-api-specs/draft-internal-api/covid-shared-datatypes-openapi.json#/components/schemas/CoreData"
+            },
+            "StateInfo": {
+                "$ref": "https://raw.githubusercontent.com/COVID19Tracking/covid-api-specs/draft-internal-api/covid-shared-datatypes-openapi.json#/components/schemas/StateInfo"
+            },
+            "BatchForPush": {
+                "description": "A full set of data from the spreadsheet to be sent in a push",
+                "required": [
+                    "context"
+                ],
+                "type": "object",
+                "properties": {
+                    "context": {
+                        "$ref": "#/components/schemas/PushContext",
+                        "description": ""
+                    },
+                    "states": {
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StateInfo"
+                        }
+                    },
+                    "coreData": {
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/CoreDataInternalState"
+                        }
+                    }
+                }
+            },
+            "PushContext": {
+                "description": "Metadata about a push",
+                "required": [
+                    "dataEntryType"
+                ],
+                "type": "object",
+                "properties": {
+                    "shiftLead": {
+                        "description": "An identifier for the shift lead responsible for the batch",
+                        "type": "string"
+                    },
+                    "batchNote": {
+                        "description": "Additonal notes explaining the batch",
+                        "type": "string"
+                    },
+                    "dataEntryType": {
+                        "description": "Describes the type of batch. A daily push?",
+                        "enum": [
+                            "daily"
+                        ],
+                        "type": "string"
+                    }
+                }
+            },
+            "BatchPostResult": {
+                "title": "Root Type for BatchPostResult",
+                "description": "Returned by a sucuessful batch operation",
+                "required": [
+                    "batchId",
+                    "isPublished"
+                ],
+                "type": "object",
+                "properties": {
+                    "batchId": {
+                        "format": "int32",
+                        "description": "The ID of the batch operation",
+                        "type": "integer"
+                    },
+                    "isPublished": {
+                        "description": "True if the batch is in the published state, false if it is in the preview state",
+                        "type": "boolean"
+                    }
+                },
+                "example": {
+                    "batchId": 123,
+                    "isPublished": false
+                }
+            },
+            "CoreDataInternal": {
+                "description": "Data fields pushed from the data entry spreadsheet to the database, including all CoreData",
+                "type": "object",
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "privateNotes": {
+                                "description": "Private notes from the data entry team",
+                                "type": "string"
+                            },
+                            "checker": {
+                                "description": "An identifier (typically initials) for the checker from the Data Entry team",
+                                "type": "string"
+                            },
+                            "doubleChecker": {
+                                "description": "An identifier (typically initials) for the double checker from the Data Entry team",
+                                "type": "string"
+                            },
+                            "dataQualityGrade": {
+                                "description": "",
+                                "type": "string"
+                            },
+                            "lastUpdateIsoUtc": {
+                                "format": "date-time",
+                                "description": "The \"as-of\" datetime of the data source (not when the data was published)",
+                                "type": "string"
+                            },
+                            "dateChecked": {
+                                "format": "date-time",
+                                "description": "The datetime we last visited their website",
+                                "type": "string"
+                            },
+                            "publicationDate": {
+                                "format": "date",
+                                "description": "The date that we release the data. When there are historical edits, this value will be different from the current date.",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "$ref": "#/components/schemas/CoreData"
+                    }
+                ]
+            },
+            "IntegrityErrors": {
+                "description": "Data integrity check errors ",
+                "type": "object",
+                "properties": {
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "example": {
+                    "errors": [
+                        "State 'NY' missing required value 'date'"
+                    ]
+                }
+            },
+            "Batch": {
+                "description": "",
+                "required": [
+                    "batchId"
+                ],
+                "type": "object",
+                "properties": {
+                    "batchId": {
+                        "description": "",
+                        "type": "integer"
+                    },
+                    "createdAt": {
+                        "format": "date-time",
+                        "description": "",
+                        "type": "string"
+                    },
+                    "publishedAt": {
+                        "format": "date-time",
+                        "description": "",
+                        "type": "string"
+                    },
+                    "shiftLead": {
+                        "description": "",
+                        "type": "string"
+                    },
+                    "batchNote": {
+                        "description": "",
+                        "type": "string"
+                    },
+                    "dataEntryType": {
+                        "description": "",
+                        "type": "string"
+                    },
+                    "isPublished": {
+                        "description": "",
+                        "type": "boolean"
+                    },
+                    "isRevision": {
+                        "description": "",
+                        "type": "boolean"
+                    },
+                    "coreData": {
+                        "$ref": "#/components/schemas/CoreDataInternal",
+                        "description": ""
+                    }
+                }
+            },
+            "StateCoreData": {
+                "description": "",
+                "type": "object",
+                "allOf": [
+                    {
+                        "required": [
+                            "state"
+                        ],
+                        "type": "object",
+                        "properties": {
+                            "state": {
+                                "description": "State abbreviation ",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "$ref": "#/components/schemas/CoreData"
+                    }
+                ]
+            },
+            "TimeSeries": {
+                "description": "",
+                "required": [
+                    "date"
+                ],
+                "type": "object",
+                "properties": {
+                    "date": {
+                        "format": "date",
+                        "description": "",
+                        "type": "string"
+                    }
+                }
+            },
+            "CoreDataHistorical": {
+                "description": "",
+                "type": "object",
+                "allOf": [
+                    {
+                        "type": "object"
+                    },
+                    {
+                        "$ref": "#/components/schemas/TimeSeries"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CoreDataInternal"
+                    }
+                ]
+            },
+            "CoreDataHistoricalState": {
+                "description": "",
+                "required": [
+                    "state"
+                ],
+                "type": "object",
+                "allOf": [
+                    {
+                        "type": "object"
+                    },
+                    {
+                        "$ref": "#/components/schemas/TimeSeries"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CoreDataInternalState"
+                    }
+                ]
+            },
+            "CoreDataInternalState": {
+                "description": "",
+                "type": "object",
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "state": {
+                                "description": "",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "$ref": "#/components/schemas/CoreDataInternal"
+                    }
+                ]
+            },
+            "CoreDataForPush": {
+                "description": "",
+                "type": "object",
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "date": {
+                                "format": "dataDate",
+                                "description": "",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "$ref": "#/components/schemas/CoreDataInternalState"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/covid-internal-openapi.json
+++ b/covid-internal-openapi.json
@@ -165,6 +165,21 @@
                 },
                 "summary": "Get a batch"
             },
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "Batch removed"
+                    },
+                    "404": {
+                        "description": "Batch ID does not exist"
+                    },
+                    "405": {
+                        "description": "Batch cannot be deleted because it is in the published state"
+                    }
+                },
+                "summary": "Remove batch",
+                "description": "This operation is only applicable to batches in the preview state. Published batches cannot be removed."
+            },
             "parameters": [
                 {
                     "examples": {
@@ -173,7 +188,7 @@
                         }
                     },
                     "name": "batchId",
-                    "description": "The batch ID to retrieve",
+                    "description": "The batch ID to manipulate",
                     "schema": {
                         "type": "integer"
                     },
@@ -266,6 +281,7 @@
             },
             "PushContext": {
                 "description": "Metadata about a push",
+                "required": [],
                 "type": "object",
                 "properties": {
                     "daily": {
@@ -408,6 +424,10 @@
                     "isRevision": {
                         "description": "",
                         "type": "boolean"
+                    },
+                    "coreData": {
+                        "$ref": "#/components/schemas/CoreDataInternal",
+                        "description": ""
                     }
                 }
             },

--- a/covid-internal-openapi.json
+++ b/covid-internal-openapi.json
@@ -1,510 +1,395 @@
-{
-    "openapi": "3.0.2",
-    "info": {
-        "title": "COVID Tracking Internal API",
-        "version": "0.0.1",
-        "description": "COVID Tracking Internal API"
-    },
-    "servers": [
-        {
-            "url": "https://internalapi.covidtracking.com/api/v1",
-            "description": ""
-        }
-    ],
-    "paths": {
-        "/states": {
-            "summary": "Retrieves the list of states and associated metadata",
-            "description": "The project includes Washington DC and US territories as states",
-            "get": {
-                "tags": [
-                    "states"
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/StateInfo"
-                                    }
-                                }
-                            }
-                        },
-                        "description": "successful operation"
-                    }
-                },
-                "summary": "Retrieve state metadata"
-            }
-        },
-        "/public/states/daily": {
-            "get": {
-                "tags": [
-                    "public"
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CoreDataHistoricalState"
-                                }
-                            }
-                        },
-                        "description": "States daily time series"
-                    }
-                },
-                "summary": "States historical data. Entries saved each day at 4 pm ET."
-            }
-        },
-        "/public/us/daily": {
-            "get": {
-                "tags": [
-                    "public"
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/CoreDataHistorical"
-                                    }
-                                }
-                            }
-                        },
-                        "description": "Daily time series data"
-                    }
-                },
-                "summary": "US historical data. Entries saved each day at 4 pm ET."
-            }
-        },
-        "/batches": {
-            "get": {
-                "tags": [
-                    "batches"
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Batch"
-                                    }
-                                }
-                            }
-                        },
-                        "description": "Retrieve all known batches"
-                    }
-                },
-                "summary": "Get all known batches"
-            },
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/BatchForPush"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "tags": [
-                    "batches"
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/BatchPostResult"
-                                }
-                            }
-                        },
-                        "description": "successful operation"
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/IntegrityErrors"
-                                }
-                            }
-                        },
-                        "description": "Data integrity validation failed"
-                    }
-                },
-                "summary": "Push a new batch of data to the database",
-                "description": "The newly added core data will be in the preview state until published. \nUpdated StateInfo will be immediately edited."
-            }
-        },
-        "/batches/{batchId}": {
-            "summary": "Retrieve a batch",
-            "get": {
-                "tags": [
-                    "batches"
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Batch"
-                                }
-                            }
-                        },
-                        "description": "Retrieve a batch"
-                    },
-                    "404": {
-                        "description": "No such batch ID exists"
-                    }
-                },
-                "summary": "Get a batch"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Batch removed"
-                    },
-                    "404": {
-                        "description": "Batch ID does not exist"
-                    },
-                    "405": {
-                        "description": "Batch cannot be deleted because it is in the published state"
-                    }
-                },
-                "summary": "Remove batch",
-                "description": "This operation is only applicable to batches in the preview state. Published batches cannot be removed."
-            },
-            "parameters": [
-                {
-                    "examples": {
-                        "exampleBatchId": {
-                            "value": "1234"
-                        }
-                    },
-                    "name": "batchId",
-                    "description": "The batch ID to manipulate",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                }
-            ]
-        },
-        "/batches/{batchId}/publish": {
-            "post": {
-                "tags": [
-                    "batches"
-                ],
-                "parameters": [
-                    {
-                        "name": "batchId",
-                        "description": "The batch ID to be published (must be in the preview state). ",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/BatchPostResult"
-                                }
-                            }
-                        },
-                        "description": "Batch has been sucuessfully published"
-                    },
-                    "404": {
-                        "description": "No batch ID exists with the specified batchId"
-                    }
-                },
-                "summary": "Publish batch",
-                "description": "Publish a batch currently in the preview state"
-            },
-            "parameters": [
-                {
-                    "name": "batchId",
-                    "description": "ID of the batch to publish",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                }
-            ]
-        }
-    },
-    "components": {
-        "schemas": {
-            "CoreData": {
-                "$ref": "https://raw.githubusercontent.com/COVID19Tracking/covid-api-specs/draft-internal-api/covid-shared-datatypes-openapi.json#/components/schemas/CoreData"
-            },
-            "StateInfo": {
-                "$ref": "https://raw.githubusercontent.com/COVID19Tracking/covid-api-specs/draft-internal-api/covid-shared-datatypes-openapi.json#/components/schemas/StateInfo"
-            },
-            "BatchForPush": {
-                "description": "A full set of data from the spreadsheet to be sent in a push",
-                "required": [
-                    "context"
-                ],
-                "type": "object",
-                "properties": {
-                    "context": {
-                        "$ref": "#/components/schemas/PushContext",
-                        "description": ""
-                    },
-                    "states": {
-                        "description": "",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/StateInfo"
-                        }
-                    },
-                    "coreData": {
-                        "description": "",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/CoreDataInternal"
-                        }
-                    }
-                }
-            },
-            "PushContext": {
-                "description": "Metadata about a push",
-                "required": [],
-                "type": "object",
-                "properties": {
-                    "daily": {
-                        "description": "Does this push contain a daily push?",
-                        "type": "boolean"
-                    },
-                    "shiftLead": {
-                        "description": "An identifier for the shift lead responsible for the batch",
-                        "type": "string"
-                    },
-                    "batchNote": {
-                        "description": "Additonal notes explaining the batch",
-                        "type": "string"
-                    }
-                }
-            },
-            "BatchPostResult": {
-                "title": "Root Type for BatchPostResult",
-                "description": "Returned by a sucuessful batch operation",
-                "required": [
-                    "batchId",
-                    "isPublished"
-                ],
-                "type": "object",
-                "properties": {
-                    "batchId": {
-                        "format": "int32",
-                        "description": "The ID of the batch operation",
-                        "type": "integer"
-                    },
-                    "isPublished": {
-                        "description": "True if the batch is in the published state, false if it is in the preview state",
-                        "type": "boolean"
-                    }
-                },
-                "example": {
-                    "batchId": 123,
-                    "isPublished": false
-                }
-            },
-            "CoreDataInternal": {
-                "description": "Data fields pushed from the data entry spreadsheet to the database, including all CoreData",
-                "type": "object",
-                "allOf": [
-                    {
-                        "type": "object",
-                        "properties": {
-                            "privateNotes": {
-                                "description": "Private notes from the data entry team",
-                                "type": "string"
-                            },
-                            "checker": {
-                                "description": "An identifier (typically initials) for the checker from the Data Entry team",
-                                "type": "string"
-                            },
-                            "doubleChecker": {
-                                "description": "An identifier (typically initials) for the double checker from the Data Entry team",
-                                "type": "string"
-                            },
-                            "dataQualityGrade": {
-                                "description": "",
-                                "type": "string"
-                            },
-                            "lastUpdateIsoUtc": {
-                                "format": "date-time",
-                                "description": "The \"as-of\" datetime of the data source (not when the data was published)",
-                                "type": "string"
-                            },
-                            "dateChecked": {
-                                "format": "date-time",
-                                "description": "The datetime we last visited their website",
-                                "type": "string"
-                            },
-                            "publicationDate": {
-                                "format": "date",
-                                "description": "The date that we release the data. When there are historical edits, this value will be different from the current date.",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    {
-                        "$ref": "#/components/schemas/CoreData"
-                    }
-                ]
-            },
-            "IntegrityErrors": {
-                "description": "Data integrity check errors ",
-                "type": "object",
-                "properties": {
-                    "errors": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "example": {
-                    "errors": [
-                        "State 'NY' missing required value 'date'"
-                    ]
-                }
-            },
-            "Batch": {
-                "description": "",
-                "required": [
-                    "batchId"
-                ],
-                "type": "object",
-                "properties": {
-                    "batchId": {
-                        "description": "",
-                        "type": "integer"
-                    },
-                    "createdAt": {
-                        "format": "date-time",
-                        "description": "",
-                        "type": "string"
-                    },
-                    "publishedAt": {
-                        "format": "date-time",
-                        "description": "",
-                        "type": "string"
-                    },
-                    "shiftLead": {
-                        "description": "",
-                        "type": "string"
-                    },
-                    "batchNote": {
-                        "description": "",
-                        "type": "string"
-                    },
-                    "dataEntryType": {
-                        "description": "",
-                        "type": "string"
-                    },
-                    "isPublished": {
-                        "description": "",
-                        "type": "boolean"
-                    },
-                    "isRevision": {
-                        "description": "",
-                        "type": "boolean"
-                    },
-                    "coreData": {
-                        "$ref": "#/components/schemas/CoreDataInternal",
-                        "description": ""
-                    }
-                }
-            },
-            "StateCoreData": {
-                "description": "",
-                "type": "object",
-                "allOf": [
-                    {
-                        "required": [
-                            "state"
-                        ],
-                        "type": "object",
-                        "properties": {
-                            "state": {
-                                "description": "State abbreviation ",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    {
-                        "$ref": "#/components/schemas/CoreData"
-                    }
-                ]
-            },
-            "TimeSeries": {
-                "description": "",
-                "required": [
-                    "date"
-                ],
-                "type": "object",
-                "properties": {
-                    "date": {
-                        "format": "date",
-                        "description": "",
-                        "type": "string"
-                    }
-                }
-            },
-            "CoreDataHistorical": {
-                "description": "",
-                "type": "object",
-                "allOf": [
-                    {
-                        "type": "object"
-                    },
-                    {
-                        "$ref": "#/components/schemas/TimeSeries"
-                    },
-                    {
-                        "$ref": "#/components/schemas/CoreDataInternal"
-                    }
-                ]
-            },
-            "CoreDataHistoricalState": {
-                "description": "",
-                "required": [
-                    "state"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "type": "object"
-                    },
-                    {
-                        "$ref": "#/components/schemas/TimeSeries"
-                    },
-                    {
-                        "$ref": "#/components/schemas/CoreDataInternal"
-                    }
-                ],
-                "properties": {
-                    "state": {
-                        "description": "",
-                        "type": "string"
-                    }
-                }
-            }
-        }
-    }
-}
+openapi: 3.0.2
+info:
+    title: COVID Tracking Internal API
+    version: 0.0.1
+    description: COVID Tracking Internal API
+servers:
+    -
+        url: 'https://internalapi.covidtracking.com/api/v1'
+        description: ''
+paths:
+    /public/states/daily:
+        get:
+            tags:
+                - public
+            parameters:
+                -
+                    name: preview
+                    description: |-
+                        If true, returns results using the most recent data in the preview state. 
+                        Otherwise, only published data is returned.
+                    schema:
+                        type: boolean
+                    in: query
+            responses:
+                '200':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/CoreDataHistoricalState'
+                    description: States daily time series
+            summary: States historical data. Entries saved each day at 4 pm ET.
+    /public/us/daily:
+        get:
+            tags:
+                - public
+            parameters:
+                -
+                    name: preview
+                    description: |-
+                        If true, returns results using the most recent data in the preview state. 
+                        Otherwise, only published data is returned.
+                    schema:
+                        type: boolean
+                    in: query
+            responses:
+                '200':
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: '#/components/schemas/CoreDataHistorical'
+                    description: Daily time series data
+            summary: US historical data. Entries saved each day at 4 pm ET.
+    /batches:
+        get:
+            tags:
+                - batches
+            responses:
+                '200':
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: '#/components/schemas/Batch'
+                    description: Retrieve all known batches
+            summary: Get all known batches
+        post:
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/BatchForPush'
+                required: true
+            tags:
+                - batches
+            responses:
+                '200':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/BatchPostResult'
+                    description: successful operation
+                '400':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/IntegrityErrors'
+                    description: Data integrity validation failed
+            summary: Push a new batch of data to the database
+            description: |-
+                The newly added core data will be in the preview state until published. 
+                Updated StateInfo will be immediately edited.
+    '/batches/{batchId}':
+        summary: Retrieve a batch
+        get:
+            tags:
+                - batches
+            responses:
+                '200':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Batch'
+                    description: Retrieve a batch
+                '404':
+                    description: No such batch ID exists
+            summary: Get a batch
+        delete:
+            responses:
+                '200':
+                    description: Batch removed
+                '404':
+                    description: Batch ID does not exist
+                '405':
+                    description: Batch cannot be deleted because it is in the published state
+            summary: Remove batch
+            description: >-
+                This operation is only applicable to batches in the preview state. Published batches cannot be
+                removed.
+        parameters:
+            -
+                examples:
+                    exampleBatchId:
+                        value: '1234'
+                name: batchId
+                description: The batch ID to manipulate
+                schema:
+                    type: integer
+                in: path
+                required: true
+    '/batches/{batchId}/publish':
+        post:
+            tags:
+                - batches
+            parameters:
+                -
+                    name: batchId
+                    description: 'The batch ID to be published (must be in the preview state). '
+                    schema:
+                        type: integer
+                    in: path
+                    required: true
+            responses:
+                '200':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/BatchPostResult'
+                    description: Batch has been sucuessfully published
+                '404':
+                    description: No batch ID exists with the specified batchId
+            summary: Publish batch
+            description: Publish a batch currently in the preview state
+        parameters:
+            -
+                name: batchId
+                description: ID of the batch to publish
+                schema:
+                    type: integer
+                in: path
+                required: true
+    /public/states/info:
+        summary: Retrieves the list of states and associated metadata
+        description: The project includes Washington DC and US territories as states
+        get:
+            tags:
+                - public
+            responses:
+                '200':
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: '#/components/schemas/StateInfo'
+                    description: successful operation
+            summary: Retrieve state metadata
+components:
+    schemas:
+        CoreData:
+            $ref: >-
+                https://raw.githubusercontent.com/COVID19Tracking/covid-api-specs/draft-internal-api/covid-shared-datatypes-openapi.json#/components/schemas/CoreData
+        StateInfo:
+            $ref: >-
+                https://raw.githubusercontent.com/COVID19Tracking/covid-api-specs/draft-internal-api/covid-shared-datatypes-openapi.json#/components/schemas/StateInfo
+        BatchForPush:
+            description: A full set of data from the spreadsheet to be sent in a push
+            required:
+                - context
+            type: object
+            properties:
+                context:
+                    $ref: '#/components/schemas/PushContext'
+                    description: ''
+                states:
+                    description: ''
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/StateInfo'
+                coreData:
+                    description: ''
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CoreDataInternalState'
+        PushContext:
+            description: Metadata about a push
+            required:
+                - dataEntryType
+            type: object
+            properties:
+                shiftLead:
+                    description: An identifier for the shift lead responsible for the batch
+                    type: string
+                batchNote:
+                    description: Additonal notes explaining the batch
+                    type: string
+                dataEntryType:
+                    description: Describes the type of batch. A daily push?
+                    enum:
+                        - daily
+                    type: string
+        BatchPostResult:
+            title: Root Type for BatchPostResult
+            description: Returned by a sucuessful batch operation
+            required:
+                - batchId
+                - isPublished
+            type: object
+            properties:
+                batchId:
+                    format: int32
+                    description: The ID of the batch operation
+                    type: integer
+                isPublished:
+                    description: 'True if the batch is in the published state, false if it is in the preview state'
+                    type: boolean
+            example:
+                batchId: 123
+                isPublished: false
+        CoreDataInternal:
+            description: 'Data fields pushed from the data entry spreadsheet to the database, including all CoreData'
+            type: object
+            allOf:
+                -
+                    type: object
+                    properties:
+                        privateNotes:
+                            description: Private notes from the data entry team
+                            type: string
+                        checker:
+                            description: An identifier (typically initials) for the checker from the Data Entry team
+                            type: string
+                        doubleChecker:
+                            description: >-
+                                An identifier (typically initials) for the double checker from the Data Entry
+                                team
+                            type: string
+                        dataQualityGrade:
+                            description: ''
+                            type: string
+                        lastUpdateIsoUtc:
+                            format: date-time
+                            description: The "as-of" datetime of the data source (not when the data was published)
+                            type: string
+                        dateChecked:
+                            format: date-time
+                            description: The datetime we last visited their website
+                            type: string
+                        publicationDate:
+                            format: date
+                            description: >-
+                                The date that we release the data. When there are historical edits, this value
+                                will be different from the current date.
+                            type: string
+                -
+                    $ref: '#/components/schemas/CoreData'
+        IntegrityErrors:
+            description: 'Data integrity check errors '
+            type: object
+            properties:
+                errors:
+                    type: array
+                    items:
+                        type: string
+            example:
+                errors:
+                    - State 'NY' missing required value 'date'
+        Batch:
+            description: ''
+            required:
+                - batchId
+            type: object
+            properties:
+                batchId:
+                    description: ''
+                    type: integer
+                createdAt:
+                    format: date-time
+                    description: ''
+                    type: string
+                publishedAt:
+                    format: date-time
+                    description: ''
+                    type: string
+                shiftLead:
+                    description: ''
+                    type: string
+                batchNote:
+                    description: ''
+                    type: string
+                dataEntryType:
+                    description: ''
+                    type: string
+                isPublished:
+                    description: ''
+                    type: boolean
+                isRevision:
+                    description: ''
+                    type: boolean
+                coreData:
+                    $ref: '#/components/schemas/CoreDataInternal'
+                    description: ''
+        StateCoreData:
+            description: ''
+            type: object
+            allOf:
+                -
+                    required:
+                        - state
+                    type: object
+                    properties:
+                        state:
+                            description: 'State abbreviation '
+                            type: string
+                -
+                    $ref: '#/components/schemas/CoreData'
+        TimeSeries:
+            description: ''
+            required:
+                - date
+            type: object
+            properties:
+                date:
+                    format: date
+                    description: ''
+                    type: string
+        CoreDataHistorical:
+            description: ''
+            type: object
+            allOf:
+                -
+                    type: object
+                -
+                    $ref: '#/components/schemas/TimeSeries'
+                -
+                    $ref: '#/components/schemas/CoreDataInternal'
+        CoreDataHistoricalState:
+            description: ''
+            required:
+                - state
+            type: object
+            allOf:
+                -
+                    type: object
+                -
+                    $ref: '#/components/schemas/TimeSeries'
+                -
+                    $ref: '#/components/schemas/CoreDataInternalState'
+        CoreDataInternalState:
+            description: ''
+            type: object
+            allOf:
+                -
+                    type: object
+                    properties:
+                        state:
+                            description: ''
+                            type: string
+                -
+                    $ref: '#/components/schemas/CoreDataInternal'
+        CoreDataForPush:
+            description: ''
+            type: object
+            allOf:
+                -
+                    type: object
+                    properties:
+                        date:
+                            format: dataDate
+                            description: ''
+                            type: string
+                -
+                    $ref: '#/components/schemas/CoreDataInternalState'

--- a/covid-internal-openapi.json
+++ b/covid-internal-openapi.json
@@ -1,0 +1,490 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "COVID Tracking Internal API",
+        "version": "0.0.1",
+        "description": "COVID Tracking Internal API"
+    },
+    "servers": [
+        {
+            "url": "internalapi.covidtracking.com/api/v1",
+            "description": ""
+        }
+    ],
+    "paths": {
+        "/states": {
+            "summary": "Retrieves the list of states and associated metadata",
+            "description": "The project includes Washington DC and US territories as states",
+            "get": {
+                "tags": [
+                    "states"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/StateInfo"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "successful operation"
+                    }
+                },
+                "summary": "Retrieve state metadata"
+            }
+        },
+        "/public/states/daily": {
+            "get": {
+                "tags": [
+                    "public"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CoreDataHistoricalState"
+                                }
+                            }
+                        },
+                        "description": "States daily time series"
+                    }
+                },
+                "summary": "States historical data. Entries saved each day at 4 pm ET."
+            }
+        },
+        "/public/us/daily": {
+            "get": {
+                "tags": [
+                    "public"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CoreDataHistorical"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Daily time series data"
+                    }
+                },
+                "summary": "US historical data. Entries saved each day at 4 pm ET."
+            }
+        },
+        "/batches": {
+            "get": {
+                "tags": [
+                    "batches"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Batch"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Retrieve all known batches"
+                    }
+                },
+                "summary": "Get all known batches"
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchForPush"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "tags": [
+                    "batches"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchPostResult"
+                                }
+                            }
+                        },
+                        "description": "successful operation"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/IntegrityErrors"
+                                }
+                            }
+                        },
+                        "description": "Data integrity validation failed"
+                    }
+                },
+                "summary": "Push a new batch of data to the database",
+                "description": "The newly added core data will be in the preview state until published. \nUpdated StateInfo will be immediately edited."
+            }
+        },
+        "/batches/{batchId}": {
+            "summary": "Retrieve a batch",
+            "get": {
+                "tags": [
+                    "batches"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Batch"
+                                }
+                            }
+                        },
+                        "description": "Retrieve a batch"
+                    },
+                    "404": {
+                        "description": "No such batch ID exists"
+                    }
+                },
+                "summary": "Get a batch"
+            },
+            "parameters": [
+                {
+                    "examples": {
+                        "exampleBatchId": {
+                            "value": "1234"
+                        }
+                    },
+                    "name": "batchId",
+                    "description": "The batch ID to retrieve",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/batches/{batchId}/publish": {
+            "post": {
+                "tags": [
+                    "batches"
+                ],
+                "parameters": [
+                    {
+                        "name": "batchId",
+                        "description": "The batch ID to be published (must be in the preview state). ",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchPostResult"
+                                }
+                            }
+                        },
+                        "description": "Batch has been sucuessfully published"
+                    },
+                    "404": {
+                        "description": "No batch ID exists with the specified batchId"
+                    }
+                },
+                "summary": "Publish batch",
+                "description": "Publish a batch currently in the preview state"
+            },
+            "parameters": [
+                {
+                    "name": "batchId",
+                    "description": "ID of the batch to publish",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        }
+    },
+    "components": {
+        "schemas": {
+            "CoreData": {
+                "$ref": "https://raw.githubusercontent.com/COVID19Tracking/covid-api-specs/draft-internal-api/covid-shared-datatypes-openapi.json#/components/schemas/CoreData"
+            },
+            "StateInfo": {
+                "$ref": "https://raw.githubusercontent.com/COVID19Tracking/covid-api-specs/draft-internal-api/covid-shared-datatypes-openapi.json#/components/schemas/StateInfo"
+            },
+            "BatchForPush": {
+                "description": "A full set of data from the spreadsheet to be sent in a push",
+                "required": [
+                    "context"
+                ],
+                "type": "object",
+                "properties": {
+                    "context": {
+                        "$ref": "#/components/schemas/PushContext",
+                        "description": ""
+                    },
+                    "states": {
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StateInfo"
+                        }
+                    },
+                    "coreData": {
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/CoreDataInternal"
+                        }
+                    }
+                }
+            },
+            "PushContext": {
+                "description": "Metadata about a push",
+                "type": "object",
+                "properties": {
+                    "daily": {
+                        "description": "Does this push contain a daily push?",
+                        "type": "boolean"
+                    },
+                    "shiftLead": {
+                        "description": "An identifier for the shift lead responsible for the batch",
+                        "type": "string"
+                    },
+                    "batchNote": {
+                        "description": "Additonal notes explaining the batch",
+                        "type": "string"
+                    }
+                }
+            },
+            "BatchPostResult": {
+                "title": "Root Type for BatchPostResult",
+                "description": "Returned by a sucuessful batch operation",
+                "required": [
+                    "batchId",
+                    "isPublished"
+                ],
+                "type": "object",
+                "properties": {
+                    "batchId": {
+                        "format": "int32",
+                        "description": "The ID of the batch operation",
+                        "type": "integer"
+                    },
+                    "isPublished": {
+                        "description": "True if the batch is in the published state, false if it is in the preview state",
+                        "type": "boolean"
+                    }
+                },
+                "example": {
+                    "batchId": 123,
+                    "isPublished": false
+                }
+            },
+            "CoreDataInternal": {
+                "description": "Data fields pushed from the data entry spreadsheet to the database, including all CoreData",
+                "type": "object",
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "privateNotes": {
+                                "description": "Private notes from the data entry team",
+                                "type": "string"
+                            },
+                            "checker": {
+                                "description": "An identifier (typically initials) for the checker from the Data Entry team",
+                                "type": "string"
+                            },
+                            "doubleChecker": {
+                                "description": "An identifier (typically initials) for the double checker from the Data Entry team",
+                                "type": "string"
+                            },
+                            "dataQualityGrade": {
+                                "description": "",
+                                "type": "string"
+                            },
+                            "lastUpdateIsoUtc": {
+                                "format": "date-time",
+                                "description": "The \"as-of\" datetime of the data source (not when the data was published)",
+                                "type": "string"
+                            },
+                            "dateChecked": {
+                                "format": "date-time",
+                                "description": "The datetime we last visited their website",
+                                "type": "string"
+                            },
+                            "publicationDate": {
+                                "format": "date",
+                                "description": "The date that we release the data. When there are historical edits, this value will be different from the current date.",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "$ref": "#/components/schemas/CoreData"
+                    }
+                ]
+            },
+            "IntegrityErrors": {
+                "description": "Data integrity check errors ",
+                "type": "object",
+                "properties": {
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "example": {
+                    "errors": [
+                        "State 'NY' missing required value 'date'"
+                    ]
+                }
+            },
+            "Batch": {
+                "description": "",
+                "required": [
+                    "batchId"
+                ],
+                "type": "object",
+                "properties": {
+                    "batchId": {
+                        "description": "",
+                        "type": "integer"
+                    },
+                    "createdAt": {
+                        "format": "date-time",
+                        "description": "",
+                        "type": "string"
+                    },
+                    "publishedAt": {
+                        "format": "date-time",
+                        "description": "",
+                        "type": "string"
+                    },
+                    "shiftLead": {
+                        "description": "",
+                        "type": "string"
+                    },
+                    "batchNote": {
+                        "description": "",
+                        "type": "string"
+                    },
+                    "dataEntryType": {
+                        "description": "",
+                        "type": "string"
+                    },
+                    "isPublished": {
+                        "description": "",
+                        "type": "boolean"
+                    },
+                    "isRevision": {
+                        "description": "",
+                        "type": "boolean"
+                    }
+                }
+            },
+            "StateCoreData": {
+                "description": "",
+                "type": "object",
+                "allOf": [
+                    {
+                        "required": [
+                            "state"
+                        ],
+                        "type": "object",
+                        "properties": {
+                            "state": {
+                                "description": "State abbreviation ",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "$ref": "#/components/schemas/CoreData"
+                    }
+                ]
+            },
+            "TimeSeries": {
+                "description": "",
+                "required": [
+                    "date"
+                ],
+                "type": "object",
+                "properties": {
+                    "date": {
+                        "format": "date",
+                        "description": "",
+                        "type": "string"
+                    }
+                }
+            },
+            "CoreDataHistorical": {
+                "description": "",
+                "type": "object",
+                "allOf": [
+                    {
+                        "type": "object"
+                    },
+                    {
+                        "$ref": "#/components/schemas/TimeSeries"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CoreDataInternal"
+                    }
+                ]
+            },
+            "CoreDataHistoricalState": {
+                "description": "",
+                "required": [
+                    "state"
+                ],
+                "type": "object",
+                "allOf": [
+                    {
+                        "type": "object"
+                    },
+                    {
+                        "$ref": "#/components/schemas/TimeSeries"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CoreDataInternal"
+                    }
+                ],
+                "properties": {
+                    "state": {
+                        "description": "",
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/covid-shared-datatypes-openapi.json
+++ b/covid-shared-datatypes-openapi.json
@@ -1,0 +1,149 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "COVID Tracking Project Shared Data Types",
+        "version": "0.0.1",
+        "description": "Project-wide data type definitions for the COVID Tracking Project"
+    },
+    "components": {
+        "schemas": {
+            "StateInfo": {
+                "type": "object",
+                "properties": {
+                    "state": {
+                        "nullable": false,
+                        "description": "State or territory postal code abbreviation.",
+                        "type": "string",
+                        "example": "CA"
+                    },
+                    "name": {
+                        "nullable": false,
+                        "description": "Full state or territory name.",
+                        "type": "string",
+                        "example": "California"
+                    },
+                    "covid19SiteOld": {
+                        "nullable": true,
+                        "deprecated": true,
+                        "description": "DEPRECATED",
+                        "type": "string"
+                    },
+                    "covid19Site": {
+                        "nullable": true,
+                        "description": "Webpage dedicated to making results available to the public. More likely to contain numbers. We make regular screenshots of this URL.",
+                        "type": "string"
+                    },
+                    "covid19SiteSecondary": {
+                        "nullable": true,
+                        "description": "Typically more informational.",
+                        "type": "string"
+                    },
+                    "twitter": {
+                        "nullable": true,
+                        "description": "Twitter for the State Health Department.",
+                        "type": "string",
+                        "example": "@CAPublicHealth"
+                    },
+                    "pui": {
+                        "nullable": true,
+                        "deprecated": true,
+                        "description": "DEPRECATED—Person Under Investigation; it is meant to capture positive, negative, and pending test results.",
+                        "type": "string",
+                        "example": "Only positives"
+                    },
+                    "pum": {
+                        "nullable": false,
+                        "deprecated": true,
+                        "description": "DEPRECATED—Person Under Monitoring; we don’t collect these numbers as they are reported far less consistently across states.",
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "notes": {
+                        "nullable": true,
+                        "description": "Notes about the information available and how we collect or record it.",
+                        "type": "string"
+                    },
+                    "fips": {
+                        "nullable": false,
+                        "description": "Federal Information Processing Standard state code.",
+                        "type": "string",
+                        "example": "06"
+                    }
+                }
+            },
+            "CoreData": {
+                "title": "Root Type for CoreData",
+                "description": "The core set of data reported by the COVID Tracking Project",
+                "type": "object",
+                "properties": {
+                    "positive": {
+                        "nullable": true,
+                        "description": "Total cumulative positive test results.",
+                        "type": "integer"
+                    },
+                    "negative": {
+                        "nullable": true,
+                        "description": "Total cumulative negative test results",
+                        "type": "integer"
+                    },
+                    "pending": {
+                        "nullable": true,
+                        "description": "Tests that have been submitted to a lab but no results have been reported yet.",
+                        "type": "integer"
+                    },
+                    "hospitalizedCurrently": {
+                        "nullable": true,
+                        "description": "Number of individuals currently hospitalized.",
+                        "type": "integer"
+                    },
+                    "hospitalizedCumulative": {
+                        "nullable": true,
+                        "description": "Total number of individuals that have been hospitalized, including those that have been discharged.",
+                        "type": "integer"
+                    },
+                    "inIcuCurrently": {
+                        "nullable": true,
+                        "description": "Number of individuals currently in an ICU.",
+                        "type": "integer"
+                    },
+                    "inIcuCumulative": {
+                        "nullable": true,
+                        "description": "Total number of individuals that have been in the ICU.",
+                        "type": "integer"
+                    },
+                    "onVentilatorCurrently": {
+                        "nullable": true,
+                        "description": "Number of individuals currently on a ventilator.",
+                        "type": "integer"
+                    },
+                    "onVentilatorCumulative": {
+                        "nullable": true,
+                        "description": "Total number of individuals that have been on a ventilator.",
+                        "type": "integer"
+                    },
+                    "recovered": {
+                        "nullable": true,
+                        "description": "Total number of individuals that have tested negative after a previous positive test.",
+                        "type": "integer"
+                    },
+                    "death": {
+                        "nullable": true,
+                        "description": "Total cumulative number of people that have died.",
+                        "type": "integer"
+                    },
+                    "hospitalized": {
+                        "nullable": true,
+                        "description": "Total cumulative number of people hospitalized.",
+                        "type": "integer"
+                    },
+                    "notes": {
+                        "nullable": true,
+                        "description": "Public Notes related to state data",
+                        "type": "string",
+                        "example": "NOTE: \"total\", \"posNeg\", \"hospitalized\" will be removed in the future."
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I'm not 100% positive on every detail here, but this attempts to lay out all the data types and realigns them all around the spreadsheet, the data dictionary, our design doc, some clarifying discussions, and the existing public API. It's very much a draft and could use a few more pairs of eyes. Suggestions extremely welcome

The easiest way to view this is to look at https://studio-ws.apicur.io/sharing/9aef82b7-4132-4603-add0-39cf27415dae, which will present everything in a nice little viewer.   

Still missing:
- Security/API key for posting
- Some examples (easier to copy/paste once the spec is firmed up and we have an initial implementation)
- The internal API file contains a cross-reference to the shared data types API file to pull in CoreData and StateInfo. This URL includes the branch name so that everything can be easily viewed, but that will need to be updated. 