### PR TITLE
Adding a /batches/edit endpoint	to internal API.

### DIFF
--- a/covid-internal-openapi.json
+++ b/covid-internal-openapi.json
@@ -265,6 +265,49 @@
                 },
                 "summary": "Retrieve state metadata"
             }
+        },
+        "/batches/edit": {
+            "summary": "Submit a set of rows to edit",
+            "description": "Note that it is expected that each CoreData row has an existing corresponding row already stored in the DB for the state and date it represents.",
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchForEdit"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "tags": [
+                    "batches"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchPostResult"
+                                }
+                            }
+                        },
+                        "description": "successful operation"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/IntegrityErrors"
+                                }
+                            }
+                        },
+                        "description": "Data integrity validation failed"
+                    }
+                },
+                "summary": "Push an \"edit\" batch of data to the database",
+                "description": "These core data rows will be in the preview state until this edit batch is published."
+            }
         }
     },
     "components": {
@@ -320,7 +363,8 @@
                     "dataEntryType": {
                         "description": "Describes the type of batch. A daily push?",
                         "enum": [
-                            "daily"
+                            "daily",
+                            "edit"
                         ],
                         "type": "string"
                     }
@@ -381,11 +425,6 @@
                             "dateChecked": {
                                 "format": "date-time",
                                 "description": "The datetime we last visited their website",
-                                "type": "string"
-                            },
-                            "publicationDate": {
-                                "format": "date",
-                                "description": "The date that we release the data. When there are historical edits, this value will be different from the current date.",
                                 "type": "string"
                             }
                         }
@@ -563,6 +602,26 @@
                         "$ref": "#/components/schemas/CoreDataInternalState"
                     }
                 ]
+            },
+            "BatchForEdit": {
+                "description": "A subset of data from the spreadsheet to be sent in an edit push",
+                "required": [
+                    "context"
+                ],
+                "type": "object",
+                "properties": {
+                    "context": {
+                        "$ref": "#/components/schemas/PushContext",
+                        "description": "Note that the dataEntryType enum here must be set to \"edit\"."
+                    },
+                    "coreData": {
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/CoreDataInternalState"
+                        }
+                    }
+                }
             }
         }
     }

--- a/covid-internal-openapi.json
+++ b/covid-internal-openapi.json
@@ -313,10 +313,10 @@
     "components": {
         "schemas": {
             "CoreData": {
-                "$ref": "https://raw.githubusercontent.com/COVID19Tracking/covid-api-specs/draft-internal-api/covid-shared-datatypes-openapi.json#/components/schemas/CoreData"
+                "$ref": "https://raw.githubusercontent.com/COVID19Tracking/covid-api-specs/master/covid-shared-datatypes-openapi.json#/components/schemas/CoreData"
             },
             "StateInfo": {
-                "$ref": "https://raw.githubusercontent.com/COVID19Tracking/covid-api-specs/draft-internal-api/covid-shared-datatypes-openapi.json#/components/schemas/StateInfo"
+                "$ref": "https://raw.githubusercontent.com/COVID19Tracking/covid-api-specs/master/covid-shared-datatypes-openapi.json#/components/schemas/StateInfo"
             },
             "BatchForPush": {
                 "description": "A full set of data from the spreadsheet to be sent in a push",

--- a/covid-shared-datatypes-openapi.json
+++ b/covid-shared-datatypes-openapi.json
@@ -38,6 +38,11 @@
                         "description": "Typically more informational.",
                         "type": "string"
                     },
+                    "covid19SiteTertiary": {
+                        "nullable": true,
+                        "description": "Typically more informational.",
+                        "type": "string"
+                    },
                     "twitter": {
                         "nullable": true,
                         "description": "Twitter for the State Health Department.",


### PR DESCRIPTION
To support this, a couple other changes:

- adding one more "allowed" value to the dataEntryType enum ("edit")
- adding a BatchForEdit data type; does not expect a set of input states, expects an "edit" PushContext

Also, removing publicationDate and adding covid19SiteTertiary to common field definitions.